### PR TITLE
Potential fix for code scanning alerts no. 1 and 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: Lint
 on:
   - push
+permissions:
+  contents: read
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
 on:
   - push
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/motorpilotltd/feedback-tool/security/code-scanning/2](https://github.com/motorpilotltd/feedback-tool/security/code-scanning/2)

To fix this, define explicit least-privilege GitHub token permissions in `.github/workflows/lint.yml`.  
Best approach: add a workflow-level `permissions` block right after `on` so it applies to all jobs in this workflow (currently only `lint`) without changing job behavior.

For this lint-only workflow, set:

- `contents: read`

This is sufficient for `actions/checkout` and read-only lint tasks. No new imports, methods, or dependencies are needed—just a YAML configuration edit in `.github/workflows/lint.yml` near the top-level keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
