### PR TITLE
Azure Easy Auth principal headers trusted for session login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,13 @@ AZURE_CLIENT_SECRET=
 AZURE_TENANT_ID=
 AZURE_REDIRECT_URI="${APP_URL}/auth/microsoft/callback"
 
+# Enable ONLY when this app is deployed behind Azure App Service "Easy Auth".
+# It trusts the X-MS-CLIENT-PRINCIPAL-* headers Easy Auth injects to log the
+# user in directly, avoiding a second in-app OAuth redirect (which loses deep
+# links). Must stay false anywhere the app server is reachable without Easy
+# Auth in front, otherwise those headers could be spoofed.
+AZURE_EASY_AUTH=false
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_GB

--- a/app/Http/Middleware/AuthenticateEasyAuth.php
+++ b/app/Http/Middleware/AuthenticateEasyAuth.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Authenticates the Laravel session from Azure App Service "Easy Auth" headers.
+ *
+ * When the app is deployed behind App Service Easy Auth, the platform performs
+ * the Azure AD login a layer above PHP and injects trusted principal headers on
+ * every request. This middleware trusts those headers to log the user in,
+ * avoiding a second OAuth round-trip through Socialite (which loses deep links
+ * across the redirects).
+ *
+ * SECURITY: these headers can be spoofed by any client that can reach the app
+ * server directly. They are only trustworthy when Easy Auth genuinely sits in
+ * front of the app and strips client-supplied copies. The services.azure.easy_auth
+ * flag MUST therefore only be enabled on deployments that are actually fronted
+ * by Easy Auth. When the flag is off this middleware is a complete no-op.
+ */
+class AuthenticateEasyAuth
+{
+    private const HEADER_PRINCIPAL_ID = 'X-MS-CLIENT-PRINCIPAL-ID';
+
+    private const HEADER_PRINCIPAL_NAME = 'X-MS-CLIENT-PRINCIPAL-NAME';
+
+    private const HEADER_PRINCIPAL = 'X-MS-CLIENT-PRINCIPAL';
+
+    /**
+     * Claim holding the Azure AD object id (oid). This is the value Socialite
+     * stores in provider_user_id, so it — not the X-MS-CLIENT-PRINCIPAL-ID
+     * header, which can differ by token version — is the authoritative key.
+     */
+    private const CLAIM_OBJECT_ID = 'http://schemas.microsoft.com/identity/claims/objectidentifier';
+
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        // Only trust Easy Auth headers when the deployment is configured to be
+        // behind Easy Auth. Off everywhere else, so headers can't be spoofed.
+        if (! config('services.azure.easy_auth')) {
+            return $next($request);
+        }
+
+        // Already authenticated via the Laravel session, nothing to do.
+        if ($request->user()) {
+            return $next($request);
+        }
+
+        $claims = $this->decodeClaims($request->header(self::HEADER_PRINCIPAL));
+
+        // The AAD object id is what Socialite stored in provider_user_id. Prefer
+        // the objectidentifier claim; fall back to the header for safety.
+        $providerUserId = $this->claim($claims, [self::CLAIM_OBJECT_ID])
+            ?? $request->header(self::HEADER_PRINCIPAL_ID);
+
+        // No Easy Auth identity on this request (e.g. health checks). Let the
+        // normal auth flow handle it.
+        if (empty($providerUserId)) {
+            return $next($request);
+        }
+
+        $email = $this->claim($claims, [
+            'preferred_username',
+            'email',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
+        ]) ?? $request->header(self::HEADER_PRINCIPAL_NAME);
+
+        $name = $this->claim($claims, [
+            'name',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name',
+        ]) ?? $email ?? $providerUserId;
+
+        $user = User::updateOrCreate(
+            ['provider_user_id' => $providerUserId],
+            [
+                'name' => $name,
+                'email' => $email,
+                'provider_platform' => 'azure',
+            ],
+        );
+
+        Auth::login($user);
+
+        return $next($request);
+    }
+
+    /**
+     * Decode the base64 JSON X-MS-CLIENT-PRINCIPAL header into a list of claims.
+     *
+     * @return array<int, array{typ?: string, val?: string}>
+     */
+    private function decodeClaims(?string $header): array
+    {
+        if (empty($header)) {
+            return [];
+        }
+
+        $decoded = json_decode((string) base64_decode($header, true), true);
+
+        return is_array($decoded['claims'] ?? null) ? $decoded['claims'] : [];
+    }
+
+    /**
+     * Return the value of the first claim matching one of the given types.
+     *
+     * @param  array<int, array{typ?: string, val?: string}>  $claims
+     * @param  array<int, string>  $types
+     */
+    private function claim(array $claims, array $types): ?string
+    {
+        foreach ($claims as $claim) {
+            if (in_array($claim['typ'] ?? null, $types, true) && ! empty($claim['val'])) {
+                return $claim['val'];
+            }
+        }
+
+        return null;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\AuthenticateEasyAuth;
 use App\Http\Middleware\AuthenticateFile;
 use App\Http\Middleware\CheckAppSettings;
 use App\Http\Middleware\EnsurePasswordChanged;
@@ -43,6 +44,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->web([
             AuthenticateSession::class,
+            AuthenticateEasyAuth::class,
             PreventBannedUsers::class,
             EnsurePasswordChanged::class,
             CheckAppSettings::class,

--- a/config/services.php
+++ b/config/services.php
@@ -14,6 +14,11 @@ return [
         'redirect' => env('AZURE_REDIRECT_URI'),
         'tenant' => env('AZURE_TENANT_ID'),
         // 'proxy' => env('PROXY')  // optionally
+
+        // Trust Azure App Service "Easy Auth" principal headers to log the user
+        // in, skipping the in-app Socialite OAuth round-trip. ONLY enable on
+        // deployments actually fronted by Easy Auth — see AuthenticateEasyAuth.
+        'easy_auth' => env('AZURE_EASY_AUTH', false),
     ],
 
 ];

--- a/tests/Feature/UserAuth/EasyAuthTest.php
+++ b/tests/Feature/UserAuth/EasyAuthTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+/**
+ * Build a base64-encoded X-MS-CLIENT-PRINCIPAL header like Easy Auth injects.
+ *
+ * @param  array<int, array{typ: string, val: string}>  $claims
+ */
+function easyAuthPrincipal(array $claims): string
+{
+    return base64_encode(json_encode([
+        'auth_typ' => 'aad',
+        'claims' => $claims,
+    ]));
+}
+
+function easyAuthHeaders(string $id, string $email, ?string $name = null): array
+{
+    return [
+        // Deliberately differs from the objectidentifier claim: the claim is
+        // authoritative for provider_user_id, the header is only a fallback.
+        'X-MS-CLIENT-PRINCIPAL-ID' => 'header-'.$id,
+        'X-MS-CLIENT-PRINCIPAL-NAME' => $email,
+        'X-MS-CLIENT-PRINCIPAL' => easyAuthPrincipal(array_filter([
+            ['typ' => 'http://schemas.microsoft.com/identity/claims/objectidentifier', 'val' => $id],
+            ['typ' => 'preferred_username', 'val' => $email],
+            $name ? ['typ' => 'name', 'val' => $name] : null,
+        ])),
+    ];
+}
+
+it('logs the user in from Easy Auth headers when the flag is enabled', function () {
+    config(['services.azure.easy_auth' => true]);
+
+    $this->withHeaders(easyAuthHeaders('oid-123', 'jane@example.com', 'Jane Doe'))
+        ->get('/')
+        ->assertOk();
+
+    $this->assertAuthenticated();
+    $user = User::firstWhere('provider_user_id', 'oid-123');
+    expect($user)->not->toBeNull()
+        ->and($user->email)->toBe('jane@example.com')
+        ->and($user->name)->toBe('Jane Doe')
+        ->and($user->provider_platform)->toBe('azure');
+});
+
+it('reuses the existing account matched by principal id', function () {
+    config(['services.azure.easy_auth' => true]);
+
+    $existing = User::factory()->create([
+        'provider_user_id' => 'oid-123',
+        'provider_platform' => 'azure',
+        'email' => 'old@example.com',
+    ]);
+
+    $this->withHeaders(easyAuthHeaders('oid-123', 'new@example.com', 'Jane Doe'))
+        ->get('/')
+        ->assertOk();
+
+    $this->assertAuthenticatedAs($existing->fresh());
+    expect(User::where('provider_user_id', 'oid-123')->count())->toBe(1)
+        ->and($existing->fresh()->email)->toBe('new@example.com');
+});
+
+it('ignores Easy Auth headers when the flag is disabled', function () {
+    config(['services.azure.easy_auth' => false]);
+
+    $this->withHeaders(easyAuthHeaders('oid-123', 'jane@example.com'))
+        ->get('/')
+        ->assertOk();
+
+    $this->assertGuest();
+    expect(User::where('provider_user_id', 'oid-123')->exists())->toBeFalse();
+});
+
+it('falls back to the principal id header when the objectidentifier claim is absent', function () {
+    config(['services.azure.easy_auth' => true]);
+
+    $this->withHeaders([
+        'X-MS-CLIENT-PRINCIPAL-ID' => 'header-only-id',
+        'X-MS-CLIENT-PRINCIPAL-NAME' => 'jane@example.com',
+        'X-MS-CLIENT-PRINCIPAL' => easyAuthPrincipal([
+            ['typ' => 'preferred_username', 'val' => 'jane@example.com'],
+        ]),
+    ])->get('/')->assertOk();
+
+    $this->assertAuthenticated();
+    expect(User::where('provider_user_id', 'header-only-id')->exists())->toBeTrue();
+});
+
+it('does nothing when no principal header is present', function () {
+    config(['services.azure.easy_auth' => true]);
+
+    $this->get('/')->assertOk();
+
+    $this->assertGuest();
+});


### PR DESCRIPTION
Behind App Service Easy Auth the platform authenticates against Azure AD a layer above the app, so deep links were lost to a second in-app OAuth round-trip. A new AuthenticateEasyAuth middleware trusts the X-MS-CLIENT-PRINCIPAL-* headers to log the user in directly, keying on the objectidentifier claim that matches the stored provider_user_id.

Gated behind the AZURE_EASY_AUTH flag (off by default) so the headers are only trusted where Easy Auth genuinely fronts the app and strips client-supplied copies; the Socialite login path is untouched when off.